### PR TITLE
feat(flake): added flake for nix environments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 @girs/
+./results/*

--- a/README.md
+++ b/README.md
@@ -5,7 +5,25 @@ A desktop shell based on [Ags](https://github.com/Aylur/ags). Currently supports
 
 ![image](https://i.imgur.com/vBy0QRd.png)
 
+## Nix/NixOS
+
+If you use Nix or NixOS, you can run Delta Shell with all dependencies managed automatically:
+
+```bash
+nix run github:sameoldlab/delta-shell
+```
+
+For development, enter a shell with all dependencies:
+
+```bash
+nix develop
+```
+
+No manual installation of dependencies is required when using Nix.
+
 ## Dependencies
+
+> **Note:** If you use Nix, you can skip this section. All dependencies are handled by the flake.
 
 ### Required
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "ags": {
+      "inputs": {
+        "astal": [
+          "astal"
+        ],
+        "gnim": "gnim",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752328525,
+        "narHash": "sha256-0aaVFLQxY1dKIS5jzwhbO847yIdr3U0o2heUzC5iat4=",
+        "owner": "aylur",
+        "repo": "ags",
+        "rev": "2eb3ea54311b0f7ba9d333d661d12cda1ed5507e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aylur",
+        "repo": "ags",
+        "type": "github"
+      }
+    },
+    "astal": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752404970,
+        "narHash": "sha256-XULTToDUkIshNXEO+YP2mAHdQv8bxWDvKjbamBfOC8E=",
+        "owner": "aylur",
+        "repo": "astal",
+        "rev": "2c5eb54f39e1710c6e2c80915a240978beb3269a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aylur",
+        "repo": "astal",
+        "type": "github"
+      }
+    },
+    "astal_niri": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752583035,
+        "narHash": "sha256-FxEJnoBzbQeFkdm7rggXK5vfwNA5imCQzIJy6VKF+64=",
+        "owner": "sameoldlab",
+        "repo": "astal",
+        "rev": "5c36714346be2034a45741c997fed30501e4e72a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sameoldlab",
+        "ref": "feat/niri",
+        "repo": "astal",
+        "type": "github"
+      }
+    },
+    "gnim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1751928958,
+        "narHash": "sha256-vQY2L+Hnp6F1MHFa3UbMft1goGw3iODI5M+96Z7P+9Q=",
+        "owner": "aylur",
+        "repo": "gnim",
+        "rev": "9bffa83f52f711b13e3c139454623a9aea4f5552",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aylur",
+        "repo": "gnim",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ags": "ags",
+        "astal": "astal",
+        "astal_niri": "astal_niri",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    astal = {
+      url = "github:aylur/astal";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    astal_niri = {
+      url = "github:sameoldlab/astal?ref=feat/niri";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ags = {
+      url = "github:aylur/ags";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.astal.follows = "astal";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    astal,
+    astal_niri,
+    ags,
+  }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    packages.${system}.default = pkgs.stdenvNoCC.mkDerivation {
+      name = "delta-shell";
+      src = ./.;
+
+      nativeBuildInputs = with pkgs; [
+        wrapGAppsHook
+        gobject-introspection
+        esbuild
+      ];
+
+      buildInputs =
+        (with pkgs; [
+          gjs
+          glib
+          gtk4
+          brightnessctl
+          dart-sass
+          gpu-screen-recorder
+          cliphist
+          bluez
+        ])
+        ++ (with astal.packages.${system}; [
+          io
+          astal4
+        ])
+        ++ [
+          astal_niri.packages.${system}.niri
+          ags.packages.${system}.agsFull
+        ];
+
+      installPhase = ''
+        mkdir -p $out/bin
+
+        esbuild \
+          --bundle src/app.js \
+          --outfile=$out/bin/my-shell \
+          --format=esm \
+          --sourcemap=inline \
+          --external:gi://\*
+      '';
+    };
+  };
+}


### PR DESCRIPTION
This pull request introduces Nix support for the project, allowing users to manage dependencies and run the application seamlessly using Nix or NixOS. The changes include adding a `flake.nix` file for Nix integration, updating the documentation to reflect the new setup, and modifying the `.envrc` file to utilize the Nix flake.

### Nix integration:

* Added a `flake.nix` file to define the Nix flake, specifying dependencies and build configurations for the project. This includes integration with external repositories like `astal`, `astal_niri`, and `ags` for required packages.
* Updated `.envrc` to include `use flake`, enabling automatic use of the Nix flake environment.

### Documentation updates:

* Updated `README.md` to include instructions for running and developing the project using Nix or NixOS. Added a note clarifying that manual dependency installation is unnecessary when using Nix.