### PR TITLE
fix(readme): fixing wrong repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ yay -S aylurs-gtk-shell-git libastal-meta brightnessctl dart-sass fd bluez tuned
 If you use Nix or NixOS, you can run Delta Shell with all dependencies managed automatically:
 
 ```bash
-nix run github:sameoldlab/delta-shell
+nix run github:Sinomor/delta-shell
 ```
 
 For development, enter a shell with all dependencies:


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect a change in the GitHub repository used for running Delta Shell with Nix. The repository has been updated from `sameoldlab/delta-shell` to `Sinomor/delta-shell`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54): Updated the Nix command to use the new GitHub repository `Sinomor/delta-shell` instead of `sameoldlab/delta-shell`.