### PR TITLE
feat(mic-osd): added mic slider & osd

### DIFF
--- a/utils/icons.ts
+++ b/utils/icons.ts
@@ -44,6 +44,7 @@ export const icons = {
    web: "globe-symbolic",
    bell: "bell-symbolic",
    microphone: "mic-symbolic",
+   microphone_muted: "mic-off-symbolic",
    powermenu: {
       sleep: "moon-symbolic",
       reboot: "refresh-cw-symbolic",

--- a/widgets/control/items/sliders.tsx
+++ b/widgets/control/items/sliders.tsx
@@ -64,6 +64,34 @@ function VolumeBox() {
    );
 }
 
+function MicrophoneBox() {
+   const mic = AstalWp.get_default()?.audio!.defaultMicrophone!;
+   const level = createBinding(mic, "volume");
+   const mute = createBinding(mic, "mute");
+
+   return (
+      <overlay
+         class={level.as(
+            (v) => `slider-box microphone-box ${v < 0.05 ? "low-mic" : ""}`,
+         )}
+         valign={Gtk.Align.CENTER}
+      >
+         <image
+            $type={"overlay"}
+            iconName={mute.as((m) => m ? icons.microphone_muted : icons.microphone)}
+            pixelSize={20}
+            valign={Gtk.Align.CENTER}
+            halign={Gtk.Align.START}
+         />
+         <slider
+            onChangeValue={({ value }) => mic.set_volume(value)}
+            hexpand
+            value={level}
+         />
+      </overlay>
+   );
+}
+
 export function Sliders() {
    return (
       <box
@@ -72,6 +100,7 @@ export function Sliders() {
          class={"sliders"}
       >
          <VolumeBox />
+         <MicrophoneBox />
          {dependencies("brightnessctl") && <BrightnessBox />}
       </box>
    );

--- a/widgets/osd/osd.tsx
+++ b/widgets/osd/osd.tsx
@@ -13,6 +13,7 @@ const [visible, visible_set] = createState(false);
 function OnScreenProgress({ visible }: { visible: Accessor<boolean> }) {
    const brightness = Brightness.get_default();
    const speaker = Wp.get_default()?.get_default_speaker();
+   const mic = Wp.get_default()?.get_default_microphone();
 
    const [iconName, iconName_set] = createState("");
    const [value, value_set] = createState(0);
@@ -58,6 +59,22 @@ function OnScreenProgress({ visible }: { visible: Accessor<boolean> }) {
                   speaker.disconnect(muteconnect);
                });
             }
+            if (mic) {
+               const micVolumeConnect = mic.connect("notify::volume", () => {
+                  if (firstStart) return;
+                  const icon = mic.mute ? icons.microphone_muted : icons.microphone;
+                  show(mic.volume, icon);
+               });
+               const micMuteConnect = mic.connect("notify::mute", () => {
+                  if (firstStart) return;
+                  const icon = mic.mute ? icons.microphone_muted : icons.microphone;
+                  show(mic.volume, icon);
+               });
+               onCleanup(() => {
+                  mic.disconnect(micVolumeConnect);
+                  mic.disconnect(micMuteConnect);
+               });
+            }
          }}
       >
          <overlay class={"osd-main"}>
@@ -78,6 +95,7 @@ function OnScreenProgress({ visible }: { visible: Accessor<boolean> }) {
       </box>
    );
 }
+
 
 export default function (gdkmonitor: Gdk.Monitor) {
    const { BOTTOM, TOP } = Astal.WindowAnchor;


### PR DESCRIPTION
This pull request introduces new functionality for microphone volume control and mute status, both in the user interface and on-screen display (OSD). The changes include adding a new `MicrophoneBox` component, integrating microphone-related features into the OSD, and updating the icon set to support these features.

### Microphone volume control and mute status:

* **Added `MicrophoneBox` component**: Created a new `MicrophoneBox` component in `widgets/control/items/sliders.tsx` to display a microphone volume slider and mute status. This component uses bindings to dynamically update the UI based on the microphone's volume and mute state. (`[widgets/control/items/sliders.tsxR67-R94](diffhunk://#diff-08bc226d21478ab5e75ccb336924b53e303d5a78e05a2aa4ea5a9c50fadf36a1R67-R94)`)

* **Integrated `MicrophoneBox` into `Sliders`**: Updated the `Sliders` component to include the newly added `MicrophoneBox`, enabling users to control microphone settings alongside other sliders. (`[widgets/control/items/sliders.tsxR103](diffhunk://#diff-08bc226d21478ab5e75ccb336924b53e303d5a78e05a2aa4ea5a9c50fadf36a1R103)`)

### On-screen display (OSD) enhancements:

* **Added microphone to OSD state**: Included the default microphone in the OSD state initialization in `widgets/osd/osd.tsx`, enabling the OSD to react to microphone volume and mute changes. (`[widgets/osd/osd.tsxR16](diffhunk://#diff-23448448b6b50ec06fe897e3ace306a25b6b11362b18aee437d5fe86e58f41d8R16)`)

* **Handled microphone events in OSD**: Added event listeners in the OSD to update the icon and display microphone volume and mute changes in real-time. Disconnect logic was also implemented for cleanup. (`[widgets/osd/osd.tsxR62-R77](diffhunk://#diff-23448448b6b50ec06fe897e3ace306a25b6b11362b18aee437d5fe86e58f41d8R62-R77)`)

### Icon updates:

* **Added `microphone_muted` icon**: Extended the `icons` object in `utils/icons.ts` to include a new `microphone_muted` icon for representing the muted microphone state. (`[utils/icons.tsR47](diffhunk://#diff-5ff4d6d51242b1b3293d2028f75a864397e82075a299e1171eae6b4f41690b38R47)`)