### PR TITLE
feat: add 'icon_size' setting for bar modules

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -9,7 +9,6 @@ export const config = mkOptions(configFile, {
    transition: 0.2,
    bar: {
       size: 48,
-	  icon_size: 20,
       position: "top" as "top" | "bottom" | "left" | "right",
       modules: {
          start: ["launcher", "workspaces"],
@@ -48,6 +47,7 @@ export const config = mkOptions(configFile, {
          workspaces: {
             "workspace-format": "{id}",
             "window-format": "{indicator} {icon}",
+			"window-icon-size": 20,
             "taskbar-icons": {} as Record<string, string>,
             "hide-empty": false,
             "on-scroll-up": "workspace-up" as string | null,
@@ -203,6 +203,11 @@ export const theme = mkOptions(themeFile, {
    spacing: 10,
    shadow: true,
    radius: 8,
+   "icon-size": {
+      normal: 20,
+	  small: 16,
+	  large: 32
+   },
    window: {
       padding: 15,
       opacity: 1,

--- a/src/modules/bar/items/battery.tsx
+++ b/src/modules/bar/items/battery.tsx
@@ -4,7 +4,7 @@ import BarItem from "@/src/widgets/baritem";
 import { createBinding } from "gnim";
 import { windows_names } from "@/windows";
 import { isVertical } from "../bar";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 
 export function Battery() {
    const conf = config.bar.modules.battery;
@@ -22,7 +22,7 @@ export function Battery() {
             icon: (
                <image
                   hexpand={isVertical}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   iconName={BatteryIcon}
                />
             ),

--- a/src/modules/bar/items/clipboard.tsx
+++ b/src/modules/bar/items/clipboard.tsx
@@ -1,7 +1,7 @@
 import { icons } from "@/src/lib/icons";
 import BarItem from "@/src/widgets/baritem";
 import { windows_names } from "@/windows";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { isVertical } from "../bar";
 import { dependencies } from "@/src/lib/utils";
 
@@ -28,7 +28,7 @@ export function Clipboard() {
                <image
                   hexpand={isVertical}
                   iconName={icons.clipboard}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                />
             ),
          }}

--- a/src/modules/bar/items/cpu.tsx
+++ b/src/modules/bar/items/cpu.tsx
@@ -2,7 +2,7 @@ import BarItem from "@/src/widgets/baritem";
 import { isVertical } from "../bar";
 import { icons } from "@/src/lib/icons";
 import SystemMonitor from "@/src/services/systemmonitor";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { createBinding, With } from "gnim";
 
 export function CPU() {
@@ -17,7 +17,7 @@ export function CPU() {
             icon: (
                <image
                   iconName={icons.cpu}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   hexpand={isVertical}
                />
             ),

--- a/src/modules/bar/items/launcher.tsx
+++ b/src/modules/bar/items/launcher.tsx
@@ -1,7 +1,7 @@
 import { icons } from "@/src/lib/icons";
 import BarItem from "@/src/widgets/baritem";
 import { windows_names } from "@/windows";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { isVertical } from "../bar";
 
 export function Launcher() {
@@ -18,7 +18,7 @@ export function Launcher() {
                <image
                   hexpand={isVertical}
                   iconName={icons.search}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                />
             ),
          }}

--- a/src/modules/bar/items/microphone.tsx
+++ b/src/modules/bar/items/microphone.tsx
@@ -3,7 +3,7 @@ import AstalWp from "gi://AstalWp";
 import { icons } from "@/src/lib/icons";
 import { windows_names } from "@/windows";
 import { isVertical } from "../bar";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { createBinding } from "gnim";
 
 export function Microphone() {
@@ -24,7 +24,7 @@ export function Microphone() {
                <image
                   hexpand={isVertical}
                   iconName={icons.microphone.default}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                />
             ),
             percent: (

--- a/src/modules/bar/items/network.tsx
+++ b/src/modules/bar/items/network.tsx
@@ -4,7 +4,7 @@ import { windows_names } from "@/windows";
 import AstalNetwork from "gi://AstalNetwork";
 import { createBinding, createComputed } from "gnim";
 import { isVertical } from "../bar";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { truncateByFormat } from "@/src/lib/utils";
 
 export function Network() {
@@ -76,7 +76,7 @@ export function Network() {
             icon: (
                <image
                   hexpand={isVertical}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   iconName={getNetworkIconBinding()}
                />
             ),

--- a/src/modules/bar/items/notificationslist.tsx
+++ b/src/modules/bar/items/notificationslist.tsx
@@ -1,4 +1,4 @@
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { icons } from "@/src/lib/icons";
 import BarItem from "@/src/widgets/baritem";
 import { windows_names } from "@/windows";
@@ -27,7 +27,7 @@ export function NotificationsList() {
             icon: (
                <image
                   iconName={icons.bell}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   hexpand={isVertical}
                />
             ),

--- a/src/modules/bar/items/powermenu.tsx
+++ b/src/modules/bar/items/powermenu.tsx
@@ -1,7 +1,7 @@
 import { icons } from "@/src/lib/icons";
 import BarItem from "@/src/widgets/baritem";
 import { windows_names } from "@/windows";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { isVertical } from "../bar";
 
 export function PowerMenu() {
@@ -18,7 +18,7 @@ export function PowerMenu() {
                <image
                   hexpand={isVertical}
                   iconName={icons.powermenu.shutdown}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                />
             ),
          }}

--- a/src/modules/bar/items/quicksettings.tsx
+++ b/src/modules/bar/items/quicksettings.tsx
@@ -2,7 +2,7 @@ import { icons } from "@/src/lib/icons";
 import BarItem from "@/src/widgets/baritem";
 import { windows_names } from "@/windows";
 import { isVertical } from "../bar";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 
 export function QuickSettings() {
    const conf = config.bar.modules.quicksettings;
@@ -17,7 +17,7 @@ export function QuickSettings() {
             icon: (
                <image
                   hexpand={isVertical}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   iconName={icons.settings}
                />
             ),

--- a/src/modules/bar/items/ram.tsx
+++ b/src/modules/bar/items/ram.tsx
@@ -2,7 +2,7 @@ import BarItem from "@/src/widgets/baritem";
 import { isVertical } from "../bar";
 import { icons } from "@/src/lib/icons";
 import SystemMonitor from "@/src/services/systemmonitor";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { createBinding } from "gnim";
 
 export function RAM() {
@@ -17,7 +17,7 @@ export function RAM() {
             icon: (
                <image
                   iconName={icons.memory}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   hexpand={isVertical}
                />
             ),

--- a/src/modules/bar/items/recordindicator.tsx
+++ b/src/modules/bar/items/recordindicator.tsx
@@ -1,4 +1,4 @@
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import ScreenRecorder from "@/src/services/screenrecorder";
 import BarItem from "@/src/widgets/baritem";
 import { createBinding } from "ags";
@@ -23,7 +23,7 @@ export function RecordIndicator() {
                   hexpand={isVertical}
                   class={"record-indicator"}
                   iconName={icons.video}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                />
             ),
             progress: (

--- a/src/modules/bar/items/tray.tsx
+++ b/src/modules/bar/items/tray.tsx
@@ -75,7 +75,7 @@ export function Tray() {
                               gicon={item.gicon}
                               hexpand={isVertical}
                               tooltipMarkup={item.tooltipMarkup || item.title}
-                              pixelSize={config.bar.icon_size}
+                              pixelSize={theme['icon-size'].normal}
                            />
                            <Gtk.GestureClick
                               onPressed={() => item.about_to_show()}
@@ -141,7 +141,7 @@ export function Tray() {
             <image
                hexpand={isVertical}
                iconName={visible((v) => icon(v))}
-               pixelSize={config.bar.icon_size}
+               pixelSize={theme['icon-size'].normal}
             />
          </button>
       </box>

--- a/src/modules/bar/items/volume.tsx
+++ b/src/modules/bar/items/volume.tsx
@@ -4,7 +4,7 @@ import { Gtk } from "ags/gtk4";
 import { VolumeIcon } from "@/src/lib/icons";
 import { windows_names } from "@/windows";
 import { isVertical } from "../bar";
-import { config } from "@/options";
+import { config, theme } from "@/options";
 import { createBinding } from "gnim";
 
 export function Volume() {
@@ -25,7 +25,7 @@ export function Volume() {
                <image
                   hexpand={isVertical}
                   iconName={VolumeIcon}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                />
             ),
             percent: (

--- a/src/modules/bar/items/weather.tsx
+++ b/src/modules/bar/items/weather.tsx
@@ -45,7 +45,7 @@ export function Weather() {
             icon: (
                <image
                   iconName={data((d) => d.icon)}
-                  pixelSize={config.bar.icon_size}
+                  pixelSize={theme['icon-size'].normal}
                   hexpand={isVertical}
                />
             ),

--- a/src/modules/bar/items/workspaces/hypr.tsx
+++ b/src/modules/bar/items/workspaces/hypr.tsx
@@ -82,7 +82,7 @@ export function WorkspacesHypr({ gdkmonitor }: { gdkmonitor: Gdk.Monitor }) {
                   icon: (
                      <image
                         iconName={iconName}
-                        pixelSize={20}
+                        pixelSize={config['window-icon-size']}
                         hexpand={isVertical}
                      />
                   ),

--- a/src/modules/bar/items/workspaces/niri.tsx
+++ b/src/modules/bar/items/workspaces/niri.tsx
@@ -82,7 +82,7 @@ export function WorkspacesNiri({ gdkmonitor }: { gdkmonitor: Gdk.Monitor }) {
                   icon: (
                      <image
                         iconName={iconName}
-                        pixelSize={20}
+                        pixelSize={config.bar.modules.workspaces['window-icon-size']}
                         hexpand={isVertical}
                      />
                   ),

--- a/src/modules/notifications/notification.tsx
+++ b/src/modules/notifications/notification.tsx
@@ -69,7 +69,7 @@ export function Notification({
                class={"close"}
                focusOnClick={false}
             >
-               <image iconName={icons.close} pixelSize={16} />
+               <image iconName={icons.close} pixelSize={theme['icon-size'].small} />
             </button>
          </box>
       );

--- a/src/modules/powermenu/powermenu.tsx
+++ b/src/modules/powermenu/powermenu.tsx
@@ -20,7 +20,7 @@ function MenuButton({ icon, label, clicked }: MenuButtonProps) {
             halign={Gtk.Align.CENTER}
             spacing={theme.spacing}
          >
-            <image iconName={icon} iconSize={Gtk.IconSize.LARGE} />
+            <image iconName={icon} pixelSize={theme['icon-size'].large} />
             <label label={label} />
          </box>
       </button>


### PR DESCRIPTION
Hey, before anything else let me say Thank You for this shell, I really like it!. 

I was going to make this an issue, but since adding options is really simple I added an option to change the size of the icons, just to allow making the bar a little bit more compact. I making it a draft pull request because I'm not sure if the place where I put the config option, or it's name are correct.