### PR TITLE
fix(screenrecorder): properly capture and terminate gpu-screen-recorder process

### DIFF
--- a/src/services/screenrecorder.ts
+++ b/src/services/screenrecorder.ts
@@ -52,7 +52,7 @@ export default class ScreenRecorder extends GObject.Object {
          this.#pid = parseInt(
             (
                await bash(
-                  `gpu-screen-recorder -w portal -f 60 -a default_output -o "${this.#file}" </dev/null >/dev/null 2>&1 & echo $!`
+                  `gpu-screen-recorder -w screen -f 60 -a default_output -o "${this.#file}" </dev/null >/dev/null 2>&1 & echo $!`
                )
             ).trim(),
             10


### PR DESCRIPTION
Hello, I’m using NixOS. The recording starts correctly, but it does not stop because the `killall` command not found. On NixOS, `pkill -f gpu-screen-recorder` works instead of `killall -INT gpu-screen-recorder`.

https://github.com/user-attachments/assets/7e32896d-c1e9-49fa-9941-1a10823c8897

However, since `pkill` may also not be available, I think the best approach is to get the process ID and kill the process directly. This way, only the specific `gpu-screen-recorder` process will be terminated instead of killing all `gpu-screen-recorder` processes.

https://github.com/user-attachments/assets/188a3ffd-3357-4a73-b39e-ab496dc20e25

Additionally, if you agree, could we use `gpu-screen-recorder -w portal` instead of `gpu-screen-recorder -w screen`?

> Maybe expose this as an option (e.g. `backend: screen | portal`) and keep `screen` as the default. For tray UX, left click could start the default backend, while right click could provide an alternative start using `portal`.

https://github.com/user-attachments/assets/60626322-f71c-493c-b3ca-6e3d7bd91d26

By killing the process via PID, I was able to start multiple `gpu-screen-recorder` instances to record this video.

