### PR TITLE
Exit with code 1 when ags prints "Unknown request"

### DIFF
--- a/delta-shell
+++ b/delta-shell
@@ -12,6 +12,19 @@ else
     IS_DEV=false
 fi
 
+run_and_check() {
+    local output
+    output=$( "$@" 2>&1 )
+    local exit_code=$?
+    if [[ "$output" == *"Unknown request"* ]]; then
+        echo "$output"
+        exit 1
+    else
+        [[ -n "$output" ]] && echo "$output"
+        return $exit_code
+    fi
+}
+
 print_help() {
     cat <<EOF
 Usage: $(basename "$0") <command> [options]
@@ -64,13 +77,13 @@ main() {
                 printf "  - %s\n" "${WIDGETS[@]}"
                 exit 0
             fi
-            ags -i delta-shell request toggle "$2"
+            run_and_check ags -i delta-shell request toggle "$2"
             ;;
         help|-h|--help)
             print_help
             ;;
         *)
-            ags -i delta-shell request "$@"
+            run_and_check ags -i delta-shell request "$@"
             ;;
     esac
 }


### PR DESCRIPTION
Previously, delta-shell was exiting with the success code even when getting wrong CLI arguments. This led to a situation where a command like this: `delta-shell wrong_argument && echo success` was printing "success", which doesn't make sense. Now this is fixed.