### PR TITLE
feat: more configuration.

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -139,7 +139,7 @@ export const config = mkOptions(configFile, {
       "sort-type": "frequency" as "frequency" | "alphabetical" | null,
    },
    calendar: {
-     start_day_of_week: "monday",
+     "start-day-of-week": "monday",
    },
    clipboard: {
       enabled: true,

--- a/options.ts
+++ b/options.ts
@@ -138,6 +138,10 @@ export const config = mkOptions(configFile, {
       columns: 1,
       "sort-type": "frequency" as "frequency" | "alphabetical" | null,
    },
+   calendar: {
+     start_day_of_week: "monday",
+     week_end_days: ["saturday", "sunday"],
+   },
    clipboard: {
       enabled: true,
       "max-items": 50,

--- a/options.ts
+++ b/options.ts
@@ -140,7 +140,6 @@ export const config = mkOptions(configFile, {
    },
    calendar: {
      start_day_of_week: "monday",
-     week_end_days: ["saturday", "sunday"],
    },
    clipboard: {
       enabled: true,

--- a/options.ts
+++ b/options.ts
@@ -147,6 +147,7 @@ export const config = mkOptions(configFile, {
       "image-preview": true,
       width: 400,
       height: 500,
+      centered: false,
    },
    osd: {
       enabled: true,

--- a/src/modules/calendar/calendar.tsx
+++ b/src/modules/calendar/calendar.tsx
@@ -1,11 +1,9 @@
 import { icons } from "@/src/lib/icons";
 import { Gtk } from "ags/gtk4";
 import { createBinding, For } from "ags";
-import { theme } from "@/options";
+import { config, theme } from "@/options";
 import Calendar, { CalendarDay } from "@/src/services/calendar";
 const calendar = Calendar.get_default();
-
-const WEEK_DAYS = ["M", "T", "W", "T", "F", "S", "S"];
 
 function CalendarDayButton({ day }: { day: CalendarDay }) {
    const classes = ["calendar-button"];
@@ -26,11 +24,13 @@ function CalendarDayButton({ day }: { day: CalendarDay }) {
 }
 
 function WeekDayHeader({ day, index }: { day: string; index: number }) {
-   const isWeekend = index >= 5;
+  const weekendEndDays = calendar
+    .weekEndDays(config.calendar.week_end_days)
+    .map(n => n === 0 ? 6 : n - 1);
 
    return (
       <button
-         cssClasses={["calendar-button", isWeekend ? "weekend" : ""]}
+         cssClasses={["calendar-button", weekendEndDays.includes(index) ? "weekend" : ""]}
          focusOnClick={false}
       >
          <box halign={Gtk.Align.CENTER}>
@@ -99,7 +99,7 @@ export function CalendarModule() {
       >
          <Header />
          <box class={"weekdays"} spacing={theme.spacing}>
-            {WEEK_DAYS.map((day, index) => (
+            {calendar.weekDays(config.calendar.start_day_of_week).map((day, index) => (
                <WeekDayHeader day={day} index={index} />
             ))}
          </box>

--- a/src/modules/calendar/calendar.tsx
+++ b/src/modules/calendar/calendar.tsx
@@ -24,13 +24,10 @@ function CalendarDayButton({ day }: { day: CalendarDay }) {
 }
 
 function WeekDayHeader({ day, index }: { day: string; index: number }) {
-  const weekendEndDays = calendar
-    .weekEndDays(config.calendar.week_end_days)
-    .map(n => n === 0 ? 6 : n - 1);
-
+   const isWeekend = index >= 5;
    return (
       <button
-         cssClasses={["calendar-button", weekendEndDays.includes(index) ? "weekend" : ""]}
+         cssClasses={["calendar-button", isWeekend ? "weekend" : ""]}
          focusOnClick={false}
       >
          <box halign={Gtk.Align.CENTER}>

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -1,4 +1,5 @@
 import GObject, { register, property, getter, setter } from "ags/gobject";
+import { config } from "@/options"
 
 export type CalendarDay = {
    date: Date;
@@ -45,6 +46,37 @@ export default class Calendar extends GObject.Object {
       return this._date.getFullYear();
    }
 
+   dayToNumber(day: string): number  {
+      switch (day.trim().toLowerCase()) {
+        case 'saturday': return 6;
+        case 'friday': return 5;
+        case 'thursday': return 4;
+        case 'wednesday': return 3;
+        case 'tuesday': return 2;
+        case 'monday': return 1;
+        case 'sunday': return 0;
+        default: throw new Error(`${day} is not a day`);
+      }
+    }
+
+   weekDays(start_day_of_week: string) {
+      switch (start_day_of_week.trim().toLowerCase()) {
+        case "monday": return ["M","T","W","T","F","S","S"];
+        case "tuesday": return ["T","W","T","F","S","S","M"];
+        case "wednesday": return ["W","T","F","S","S","M","T"];
+        case "thursday": return ["T","F","S","S","M","T","W"];
+        case "friday": return ["F","S","S","M","T","W","T"];
+        case "saturday": return ["S","S","M","T","W","T","F"];
+        case "sunday": return ["S","M","T","W","T","F","S"];
+        default: throw new Error(`${start_day_of_week} is not a day`);
+      }
+    }
+
+   weekEndDays(days: string[]): number[] {
+    return days
+      .map(day => this.dayToNumber(day));
+   }
+
    @getter(Object)
    get calendar() {
       const year = this.year;
@@ -52,7 +84,7 @@ export default class Calendar extends GObject.Object {
       const now = new Date();
 
       const startOfMonth = new Date(year, month, 1);
-      const startDayOfWeek = (startOfMonth.getDay() + 6) % 7;
+      const startDayOfWeek = (startOfMonth.getDay() - this.dayToNumber(config.calendar.start_day_of_week) + 7) % 7;
 
       const days: CalendarDay[] = [];
 
@@ -69,7 +101,7 @@ export default class Calendar extends GObject.Object {
             day: currentIterDate.getDate(),
             isToday,
             isWeekend:
-               currentIterDate.getDay() === 0 || currentIterDate.getDay() === 6,
+               this.weekEndDays(config.calendar.week_end_days).includes(currentIterDate.getDay()),
             isOtherMonth: currentIterDate.getMonth() !== month,
          });
 

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -59,22 +59,20 @@ export default class Calendar extends GObject.Object {
       }
     }
 
-   weekDays(start_day_of_week: string) {
-      switch (start_day_of_week.trim().toLowerCase()) {
+   weekDays(startDayOfWeek: string) {
+      switch (startDayOfWeek.trim().toLowerCase()) {
         case "monday": return ["M","T","W","T","F","S","S"];
-        case "tuesday": return ["T","W","T","F","S","S","M"];
-        case "wednesday": return ["W","T","F","S","S","M","T"];
-        case "thursday": return ["T","F","S","S","M","T","W"];
-        case "friday": return ["F","S","S","M","T","W","T"];
-        case "saturday": return ["S","S","M","T","W","T","F"];
         case "sunday": return ["S","M","T","W","T","F","S"];
-        default: throw new Error(`${start_day_of_week} is not a day`);
+        default: throw new Error(`"${startDayOfWeek}" start day of the week have to be sunday or monday`);
       }
     }
 
-   weekEndDays(days: string[]): number[] {
-    return days
-      .map(day => this.dayToNumber(day));
+   weekEndDays(startDayOfWeek: string): number[] {
+      switch (startDayOfWeek.trim().toLowerCase()) {
+        case "monday": return [0, 6];
+        case "sunday": return [5, 6];
+        default: throw new Error(`"${startDayOfWeek}" start day of the week have to be sunday or monday`);
+      }
    }
 
    @getter(Object)
@@ -101,7 +99,7 @@ export default class Calendar extends GObject.Object {
             day: currentIterDate.getDate(),
             isToday,
             isWeekend:
-               this.weekEndDays(config.calendar.week_end_days).includes(currentIterDate.getDay()),
+               this.weekEndDays(config.calendar.start_day_of_week).includes(currentIterDate.getDay()),
             isOtherMonth: currentIterDate.getMonth() !== month,
          });
 

--- a/src/windows/clipboard.tsx
+++ b/src/windows/clipboard.tsx
@@ -3,17 +3,23 @@ import { BarItemPopup } from "../widgets/baritempopup";
 import { ClipboardModule } from "../modules/clipboard/clipboard";
 import { config, theme } from "@/options";
 import { hasBarItem } from "../lib/utils";
-const { width, height } = config.clipboard;
+import { Popup } from "../widgets/popup";
+const { width, height, centered } = config.clipboard;
 
 export function ClipboardWindow() {
-   return (
+
+   return centered ? (
+      <Popup name={windows_names.clipboard} width={width} height={height}>
+          <ClipboardModule />
+      </Popup>
+   ) : (
       <BarItemPopup
          name={windows_names.clipboard}
          module={hasBarItem("clipboard") ? "clipboard" : "launcher"}
          width={width}
          height={height}
       >
-         <ClipboardModule />
+        <ClipboardModule />
       </BarItemPopup>
    );
 }


### PR DESCRIPTION
add options for 
- start day of the week
- clipboard centered postion
```json
  "calendar": {
    "start_day_of_week": "monday"
  },
   "clipboard": {
      "centered": false,
   }

```
and adjust weekend days using start day of the week