### PR TITLE
feat(weather): add temperature unit, 12h clock, and US state config

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -179,6 +179,8 @@ export const config = mkOptions(configFile, {
    },
    weather: {
       enabled: true,
+      hour12: false,
+      units: "celsius" as "celsius" | "fahrenheit",
       location: {
          auto: false,
          coords: null as { latitude: string; longitude: string } | null,

--- a/src/modules/weather/hours.tsx
+++ b/src/modules/weather/hours.tsx
@@ -1,17 +1,18 @@
 import { Gtk } from "ags/gtk4";
 import { createBinding, For } from "ags";
 import { icons } from "@/src/lib/icons";
-import { theme } from "@/options";
+import { config, theme } from "@/options";
 import { HourlyWeather } from "@/src/services/weather";
 import Weather from "@/src/services/weather";
 
 function formatHour(timestamp: number): string {
    const date = new Date(timestamp * 1000);
    const now = new Date();
+   // minutes omitted in 12h mode to prevent last hour from clipping
    const hour = date.toLocaleTimeString([], {
-      hour12: false,
-      hour: "2-digit",
-      minute: "2-digit",
+      hour12: config.weather.hour12,
+      hour: config.weather.hour12 ? "numeric" : "2-digit",
+      ...(config.weather.hour12 ? {} : { minute: "2-digit" }),
    });
    if (date.getHours() === now.getHours()) return "Now";
    else return hour;

--- a/src/modules/weather/weather.tsx
+++ b/src/modules/weather/weather.tsx
@@ -37,7 +37,7 @@ function Header({ showArrow = false }: { showArrow?: boolean }) {
          };
 
       return {
-         label: `${location.city}, ${location.country_code}`,
+         label: `${location.city}, ${location.region ?? location.country_code}`,
       };
    });
 

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -9,6 +9,7 @@ interface LocationData {
    city: string;
    country: string;
    country_code: string;
+   region?: string;
    latitude: number;
    longitude: number;
 }
@@ -126,7 +127,7 @@ export default class Weather extends GObject.Object {
       }
    }
 
-   async location_by_coords(lat: string, lon: string) {
+   async location_by_coords(lat: string, lon: string, cityName?: string) {
       const params = {
          lat: lat,
          lon: lon,
@@ -150,15 +151,20 @@ export default class Weather extends GObject.Object {
          const json = await res.json();
          const location = json.address;
 
+         const countryCode = location.country_code.toLocaleUpperCase();
+         const iso = location["ISO3166-2-lvl4"];
+
          this.location = {
             city:
+               cityName ||
                location.hamlet ||
                location.city ||
                location.town ||
                location.village ||
                "Unknown",
             country: location.country,
-            country_code: location.country_code.toLocaleUpperCase(),
+            country_code: countryCode,
+            region: countryCode === "US" && iso ? iso.split("-")[1] : undefined,
             latitude: Number(lat),
             longitude: Number(lon),
          };
@@ -168,7 +174,14 @@ export default class Weather extends GObject.Object {
             `Weather: failed to reverse geocode coordinates (${lat}, ${lon}):`,
             error,
          );
-         this.location = {};
+         this.location = {
+            city: cityName || "Unknown",
+            country: "",
+            country_code: "",
+            latitude: Number(lat),
+            longitude: Number(lon),
+         };
+         this.update();
       }
    }
 
@@ -196,18 +209,14 @@ export default class Weather extends GObject.Object {
          }
 
          const location = json.results[0];
-
-         this.location = {
-            city: location.name,
-            country: location.country,
-            country_code: location.country_code,
-            latitude: location.latitude,
-            longitude: location.longitude,
-         };
          console.log(
             `Weather: found ${location.name}, ${location.country_code}`,
          );
-         this.update();
+         await this.location_by_coords(
+            location.latitude.toString(),
+            location.longitude.toString(),
+            location.name,
+         );
       } catch (error) {
          if (error instanceof Error && error.message === "NOT_FOUND") {
             console.error(`Weather: city ${city} not found`);
@@ -288,6 +297,7 @@ export default class Weather extends GObject.Object {
             "precipitation_probability_max",
          ],
          wind_speed_unit: "ms",
+         temperature_unit: config.weather.units,
          timezone: "auto",
          timeformat: "unixtime",
          forecast_hours: 12,


### PR DESCRIPTION
## Summary
- Add `units` ("celsius" | "fahrenheit") and `hour12` config options, defaulting to celsius/24h
- In 12h mode, hourly forecast omits minutes to prevent the last hour from clipping
- Show US state abbreviation (ISO 3166-2) instead of country code in the weather header by extracting it during reverse geocoding
- Unify city lookup to go through `location_by_coords` so region data is always resolved
- Improve reverse geocode error handling to populate a partial location and trigger an update rather than silently clearing state