### PR TITLE
fix: handle null description for default audio devices

### DIFF
--- a/src/modules/volume/volume.tsx
+++ b/src/modules/volume/volume.tsx
@@ -147,7 +147,7 @@ function DefaultOutput() {
          >
             <box hexpand>
                <label
-                  label={description}
+                  label={description((d) => d ?? "")}
                   hexpand
                   halign={Gtk.Align.START}
                   ellipsize={Pango.EllipsizeMode.END}
@@ -224,7 +224,7 @@ function DefaultMicrophone() {
          >
             <box hexpand>
                <label
-                  label={description}
+                  label={description((d) => d ?? "")}
                   hexpand
                   halign={Gtk.Align.START}
                   ellipsize={Pango.EllipsizeMode.END}


### PR DESCRIPTION
## Summary
- WirePlumber's default speaker/microphone `description` can be `null` during early boot before audio devices are fully enumerated
- Passing `null` to a GTK label crashes the volume module, which kills the entire `windows()` function before the bar is created
- The process stays alive but renders no windows, so the bar silently doesn't appear

## Fix
Fall back to an empty string when `description` is null in `DefaultOutput` and `DefaultMicrophone`.