### PR TITLE
Add RAM usage in GiB

### DIFF
--- a/src/modules/bar/items/ram.tsx
+++ b/src/modules/bar/items/ram.tsx
@@ -10,7 +10,7 @@ export function RAM() {
    const systemmonitor = SystemMonitor.get_default();
    const memoryUsage = createBinding(systemmonitor, "memoryUsage"); // Percent usage
    const memoryTotal = createBinding(systemmonitor, "memoryTotal");
-   const memoryUsed = createBinding(systemmonitor, "memoryUsed"); // Usage in GBs
+   const memoryUsed = createBinding(systemmonitor, "memoryUsed"); // Usage in GiB
 
    return (
       <BarItem
@@ -28,7 +28,7 @@ export function RAM() {
                   hexpand={isVertical}
                />
             ),
-	    // Total used GBs
+	    // Total used GiB
 	    used: (
 	      <label
 	          label={memoryUsed((v) => (v / 1024 / 1024).toFixed(2))}

--- a/src/modules/bar/items/ram.tsx
+++ b/src/modules/bar/items/ram.tsx
@@ -8,8 +8,9 @@ import { createBinding } from "gnim";
 export function RAM() {
    const conf = config.bar.modules.ram;
    const systemmonitor = SystemMonitor.get_default();
-   const memoryUsage = createBinding(systemmonitor, "memoryUsage");
+   const memoryUsage = createBinding(systemmonitor, "memoryUsage"); // Percent usage
    const memoryTotal = createBinding(systemmonitor, "memoryTotal");
+   const memoryUsed = createBinding(systemmonitor, "memoryUsed"); // Usage in GBs
 
    return (
       <BarItem
@@ -27,6 +28,13 @@ export function RAM() {
                   hexpand={isVertical}
                />
             ),
+	    // Total used GBs
+	    used: (
+	      <label
+	          label={memoryUsed((v) => (v / 1024 / 1024).toFixed(2))}
+		  hexpand={isVertical}
+	       />
+	    ),
             total: (
                <label
                   label={memoryTotal((v) =>

--- a/src/modules/bar/items/ram.tsx
+++ b/src/modules/bar/items/ram.tsx
@@ -28,13 +28,13 @@ export function RAM() {
                   hexpand={isVertical}
                />
             ),
-	    // Total used GiB
-	    used: (
-	      <label
-	          label={memoryUsed((v) => (v / 1024 / 1024).toFixed(2))}
-		  hexpand={isVertical}
-	       />
-	    ),
+       	    // Total used GiB
+       	    used: (
+               <label
+          	  	  label={memoryUsed((v) => (v / 1024 / 1024).toFixed(2))}
+          	  	  hexpand={isVertical}
+          	   />
+       	    ),
             total: (
                <label
                   label={memoryTotal((v) =>

--- a/src/services/systemmonitor.ts
+++ b/src/services/systemmonitor.ts
@@ -119,7 +119,7 @@ export default class SystemMonitor extends GObject.Object {
          }
 
          this.memoryTotal = total;
-	 this.memoryUsed = total - available;
+         this.memoryUsed = total - available;
 
          if (total > 0) {
             this.memoryUsage = 1 - available / total;

--- a/src/services/systemmonitor.ts
+++ b/src/services/systemmonitor.ts
@@ -119,6 +119,7 @@ export default class SystemMonitor extends GObject.Object {
          }
 
          this.memoryTotal = total;
+	 this.memoryUsed = total - available;
 
          if (total > 0) {
             this.memoryUsage = 1 - available / total;


### PR DESCRIPTION
I worked on issue #26, but I used GiB instead of GB since the total already used that.

**I noticed a few things:**
* There was a memoryUsed object in `src/services/systemmonitor.ts` but it was never used.
* The docs say that the 'usage' label displays the memory in GiB, but it actually displays the percentage.


**A few notes on the changes I made:**
* The 'used' label displays the total memory used in GiB. This uses the previously unused memoryUsed property.
* The 'usage' and 'total' labels still work the same; I didn't modify them.