### PR TITLE
feat/keyboard-brightness

### DIFF
--- a/assets/icons/hicolor/scalable/status/ds-keyboard-brightness-symbolic.svg
+++ b/assets/icons/hicolor/scalable/status/ds-keyboard-brightness-symbolic.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg">
+  <!-- center ray -->
+  <path
+    style="fill:#000000;stroke:none"
+    d="M 11,1 h 2 v 5 h -2 z" />
+  <!-- left diagonal ray -->
+  <path
+    style="fill:#000000;stroke:none"
+    d="M 5.2928932,3.2928932 6.7071068,3.2928932 9.4142136,6 8,7.4142136 z" />
+  <!-- right diagonal ray -->
+  <path
+    style="fill:#000000;stroke:none"
+    d="M 17.292893,3.2928932 18.707107,3.2928932 15.999999,6.0000002 14.585786,7.4142136 z" />
+  <!-- left horizontal ray -->
+  <path
+    style="fill:#000000;stroke:none"
+    d="M 2,8 h 5 v 2 H 2 z" />
+  <!-- right horizontal ray -->
+  <path
+    style="fill:#000000;stroke:none"
+    d="M 17,8 h 5 v 2 h -5 z" />
+  <!-- keyboard body -->
+  <path
+    style="fill:#000000;stroke:none"
+    d="M 4,12 C 2.8954305,12 2,12.895431 2,14 v 6 c 0,1.104569 0.8954305,2 2,2 h 16 c 1.104569,0 2,-0.895431 2,-2 v -6 c 0,-1.104569 -0.895431,-2 -2,-2 z m 0,2 h 16 v 6 H 4 Z" />
+  <!-- key dots row -->
+  <rect style="fill:#000000;stroke:none" x="6" y="15.5" width="1.5" height="1.5" rx="0.5" />
+  <rect style="fill:#000000;stroke:none" x="9.25" y="15.5" width="1.5" height="1.5" rx="0.5" />
+  <rect style="fill:#000000;stroke:none" x="13.25" y="15.5" width="1.5" height="1.5" rx="0.5" />
+  <rect style="fill:#000000;stroke:none" x="16.5" y="15.5" width="1.5" height="1.5" rx="0.5" />
+  <!-- spacebar -->
+  <rect style="fill:#000000;stroke:none" x="8.5" y="18.5" width="7" height="1.5" rx="0.75" />
+</svg>

--- a/options.ts
+++ b/options.ts
@@ -129,7 +129,7 @@ export const config = mkOptions(configFile, {
    },
    quicksettings: {
       buttons: ["network", "bluetooth", "notifications", "screenrecord"],
-      sliders: ["volume", "brightness"],
+      sliders: ["volume", "brightness", "keyboard-brightness"],
    },
    launcher: {
       width: 400,

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -68,6 +68,7 @@ export const icons = {
       4: "ds-battery-4-symbolic",
    },
    brightness: "ds-sun-symbolic",
+   keyboardBrightness: "ds-keyboard-brightness-symbolic",
    video: "ds-video-symbolic",
    close: "ds-x-symbolic",
    apps_default: "application-x-executable",

--- a/src/modules/quicksettings/items/sliders.tsx
+++ b/src/modules/quicksettings/items/sliders.tsx
@@ -11,6 +11,8 @@ const wp = AstalWp.get_default();
 
 const Sliders = {
    brightness: () => (brightness.available ? <BrightnessBox /> : null),
+   "keyboard-brightness": () =>
+      brightness.kbdAvailable ? <KeyboardBrightnessBox /> : null,
    volume: () => <VolumeBox />,
    microphone: () => <MicrophoneBox />,
 } as Record<string, any>;
@@ -24,6 +26,18 @@ function BrightnessBox() {
          min={0.05}
          icon={icons.brightness}
          onChangeValue={(value) => (brightness.screen = value)}
+      />
+   );
+}
+
+function KeyboardBrightnessBox() {
+   const level = createBinding(brightness, "kbd");
+
+   return (
+      <QSSlider
+         level={level}
+         icon={icons.keyboardBrightness}
+         onChangeValue={(value) => (brightness.kbd = value)}
       />
    );
 }

--- a/src/services/brightness.ts
+++ b/src/services/brightness.ts
@@ -17,6 +17,20 @@ try {
    console.debug("Brightness: no internal displays found");
 }
 
+let kbdBacklightName = "";
+try {
+   kbdBacklightName = exec(
+      `bash -c "ls -w1 /sys/class/leds 2>/dev/null | grep kbd_backlight | head -1"`,
+   ).trim();
+   if (kbdBacklightName) {
+      console.log(
+         `Brightness: detected keyboard backlight ${kbdBacklightName}`,
+      );
+   }
+} catch (error) {
+   console.debug("Brightness: no keyboard backlight found");
+}
+
 const externalDisplayBuses: number[] = [];
 if (dependencies("ddcutil")) {
    try {
@@ -54,6 +68,7 @@ if (dependencies("ddcutil")) {
 
 const hasInternal = dependencies("brightnessctl") && !!internalDisplayName;
 const hasExternal = externalDisplayBuses.length > 0;
+const hasKbd = dependencies("brightnessctl") && !!kbdBacklightName;
 const available = hasInternal || hasExternal;
 
 const getBrightness = (): number => {
@@ -114,6 +129,22 @@ const getExternalBrightness = (bus: number): number => {
    }
 };
 
+const getKbdBrightness = (): number => {
+   if (!hasKbd) return 0;
+   try {
+      const current = parseInt(
+         exec(`brightnessctl -d ${kbdBacklightName} get`).trim(),
+      );
+      const max = parseInt(
+         exec(`brightnessctl -d ${kbdBacklightName} max`).trim(),
+      );
+      return current / (max || 1);
+   } catch (error) {
+      console.warn("Failed to read keyboard backlight brightness:", error);
+      return 0;
+   }
+};
+
 type MonitorState = {
    id: string;
    type: "internal" | "external";
@@ -132,6 +163,9 @@ export default class Brightness extends GObject.Object {
 
    #screen = available ? getBrightness() : 0;
    #available = available;
+   #kbd = hasKbd ? getKbdBrightness() : 0;
+   #kbdAvailable = hasKbd;
+   #kbdChanging = false;
    #monitors: MonitorState[] = [];
 
    @getter(Number)
@@ -142,6 +176,32 @@ export default class Brightness extends GObject.Object {
    @getter(Boolean)
    get available() {
       return this.#available;
+   }
+
+   @getter(Number)
+   get kbd() {
+      return this.#kbd;
+   }
+
+   @getter(Boolean)
+   get kbdAvailable() {
+      return this.#kbdAvailable;
+   }
+
+   @setter(Number)
+   set kbd(percent) {
+      if (!this.#kbdAvailable) return;
+      if (percent < 0) percent = 0;
+      if (percent > 1) percent = 1;
+
+      this.#kbd = percent;
+      this.notify("kbd");
+
+      this.#kbdChanging = true;
+      const value = Math.round(percent * 100);
+      bash(`brightnessctl -d ${kbdBacklightName} set ${value}% -q`).then(
+         () => (this.#kbdChanging = false),
+      );
    }
 
    @setter(Number)
@@ -202,6 +262,18 @@ export default class Brightness extends GObject.Object {
                },
             );
          }
+      }
+
+      if (this.#kbdAvailable) {
+         monitorFile(
+            `/sys/class/leds/${kbdBacklightName}/brightness`,
+            async (f) => {
+               if (this.#kbdChanging) return;
+               await readFileAsync(f);
+               this.#kbd = getKbdBrightness();
+               this.notify("kbd");
+            },
+         );
       }
    }
 


### PR DESCRIPTION
detects keyboard backlight via /sys/class/leds/kbd_backlight and adds a slider to the quick settings panel. monitors the sysfs brightness file for external changes (e.g. fn keys).